### PR TITLE
Fix to correctly publish messages.

### DIFF
--- a/bin/amqp-tool
+++ b/bin/amqp-tool
@@ -112,7 +112,7 @@ function importQueue(conn, exchange, streamController){
       return;
     }
 
-    exchange.publish(message[2].routingKey, message[0]);
+    exchange.publish(message[2].routingKey, new Buffer(message[0].data));
 
     if(argv.count && ++count == argv.count){
       stopImport();


### PR DESCRIPTION
I was unable to use node-amqp-tool since the import process always ends up filling the destination queue with json messages instead of the original message data. 

According to the documentation of node-amqp[1], when publishing to an exchange, you can pass either an Object or a Buffer congaing the message data. This change uses the Buffer approach which seem to work with both pain text messages and binary messages.

I hope you find this fix applicable for node-amqp-tool

[1] https://github.com/postwait/node-amqp#exchangepublishroutingkey-message-options

Thanks for this great tool! Cheers,
Alex
