### PR TITLE
fix(properties) - do not define null values

### DIFF
--- a/bin/amqp-tool
+++ b/bin/amqp-tool
@@ -125,7 +125,9 @@ function importQueue(conn, exchange, streamController){
     // only define existing attributes
     var messageOptions = {};
     for (var attr in message[2]) {
-      messageOptions[attr] = message[2][attr];
+      if (message[2].hasOwnProperty(attr)) {
+        messageOptions[attr] = message[2][attr];
+      }
     }
 
     exchange.publish(message[2].routingKey, message[0], messageOptions);

--- a/bin/amqp-tool
+++ b/bin/amqp-tool
@@ -122,15 +122,11 @@ function importQueue(conn, exchange, streamController){
       return;
     }
 
-    var messageOptions = {
-      //appId: messageObject.appId,
-      //timestamp: messageObject.timestamp,
-      //contentType: message[2].contentType,
-      contentEncoding: message[2].contentEncoding,
-      deliveryMode: message[2].deliveryMode,
-      headers: message[2].headers,
-      //expiration: 10000
-    };
+    // only define existing attributes
+    var messageOptions = {};
+    for (var attr in message[2]) {
+      messageOptions[attr] = message[2][attr];
+    }
 
     exchange.publish(message[2].routingKey, message[0], messageOptions);
 


### PR DESCRIPTION
node-amqp does not support null values for headers, contentEncoding, ...