### PR TITLE
Fix issue #7

### DIFF
--- a/bin/amqp-tool
+++ b/bin/amqp-tool
@@ -138,7 +138,7 @@ function importQueue(conn, exchange, streamController){
   }
 
   function stopImport(){
-    streamController.close(stream, conn.destroySoon.bind(conn));
+    streamController.close(stream, conn.destroy.bind(conn));
   }
 }
 
@@ -173,7 +173,7 @@ function exportQueue(conn, queue, streamController){
   function stopExport(consumerTag){
     queue.unsubscribe(consumerTag);
 
-    streamController.close(stream, conn.destroySoon.bind(conn));
+    streamController.close(stream, conn.destroy.bind(conn));
   }
 
 }


### PR DESCRIPTION
This pull request fixes issue #7 in the branch named “TypeError: Cannot call method 'bind' of undefined” in my fork. This bug makes it impossible to use your awesome amqp-tool. Method destroySoon of amqp.connection in amqp library is not available anymore. Use destroy method.
Thanks for merging