### PR TITLE
Add a flag to output only message body without the headers (resolve #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Options:
   --passive       set it to true if the queue already exist                                    [boolean]  [default: true]
   --durable       if specified the queue will survive a broker restart                         [boolean]
   --autoDelete    if specified the queue will be deleted when there are no more subscriptions  [boolean]
+  --onlyBody      if specified export will contain only body of messages                       [boolean]  [default: false]
   --export        export [filename], export queue's content to filename
   --import        import [filename], export file content into the queue
   --count         limit the number of message to export/import

--- a/bin/amqp-tool
+++ b/bin/amqp-tool
@@ -29,6 +29,9 @@ var VERSION = '0.0.3'
         .boolean('durable')
       .describe('autoDelete', 'if specified the queue will be deleted when there are no more subscriptions')
         .boolean('autoDelete')
+      .describe('onlyBody', 'if specified export will contain only body of messages')
+      .default('onlyBody', false)
+        .boolean('onlyBody')
     .describe('export', 'export [filename], export queue\'s content to filename')
     .describe('import', 'import [filename], export file content into the queue')
       .describe('count', 'limit the number of message to export/import')
@@ -161,7 +164,11 @@ function exportQueue(conn, queue, streamController){
 
 
   function exportMsg(message, header, deliveryInfo){
-    stream.write(JSON.stringify([message, header, deliveryInfo])+"\n");
+    if(argv.onlyBody){
+      stream.write(JSON.stringify(message)+"\n");
+    } else {
+      stream.write(JSON.stringify([message, header, deliveryInfo])+"\n");
+    }
 
     queue.shift();
 


### PR DESCRIPTION
In order to download messages for replaying later, it is beneficial to
download only the body of the message without the headers. Specifying
 flag "onlyBody" to true will supress this behavior. Setting up to
 false will not affect default behavior.